### PR TITLE
update DRA driver error injection

### DIFF
--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -315,7 +315,7 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 		logger := klog.LoggerWithValues(klog.LoggerWithName(klog.Background(), "kubelet plugin"), "node", pod.Spec.NodeName, "pod", klog.KObj(&pod))
 		loggerCtx := klog.NewContext(ctx, logger)
 		plugin, err := app.StartPlugin(loggerCtx, "/cdi", d.Name, nodename,
-			app.FileOperations{
+			app.PluginConfig{
 				Create: func(name string, content []byte) error {
 					klog.Background().Info("creating CDI file", "node", nodename, "filename", name, "content", string(content))
 					return d.createFile(&pod, name, content)

--- a/test/e2e/dra/test-driver/app/gomega.go
+++ b/test/e2e/dra/test-driver/app/gomega.go
@@ -36,7 +36,7 @@ var BeRegistered = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error
 // NodePrepareResoucesSucceeded checks that NodePrepareResources API has been called and succeeded
 var NodePrepareResourcesSucceeded = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
 	for _, call := range actualCalls {
-		if strings.HasSuffix(call.FullMethod, "/NodePrepareResources") && call.Err == nil {
+		if strings.HasSuffix(call.FullMethod, "/NodePrepareResources") && call.Response != nil && call.Err == nil {
 			return true, nil
 		}
 	}
@@ -56,7 +56,7 @@ var NodePrepareResourcesErrored = gcustom.MakeMatcher(func(actualCalls []GRPCCal
 // NodeUnprepareResoucesSucceeded checks that NodeUnprepareResources API has been called and succeeded
 var NodeUnprepareResourcesSucceeded = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
 	for _, call := range actualCalls {
-		if strings.HasSuffix(call.FullMethod, "/NodeUnprepareResources") && call.Err == nil {
+		if strings.HasSuffix(call.FullMethod, "/NodeUnprepareResources") && call.Response != nil && call.Err == nil {
 			return true, nil
 		}
 	}

--- a/test/e2e/dra/test-driver/app/gomega.go
+++ b/test/e2e/dra/test-driver/app/gomega.go
@@ -33,22 +33,42 @@ var BeRegistered = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error
 	return false, nil
 }).WithMessage("contain successful NotifyRegistrationStatus call")
 
-// NodePrepareResouceCalled checks that NodePrepareResource API has been called
-var NodePrepareResourceCalled = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
-	for _, call := range actualCalls {
-		if strings.HasSuffix(call.FullMethod, "/NodePrepareResource") && call.Err == nil {
-			return true, nil
-		}
-	}
-	return false, nil
-}).WithMessage("contain NodePrepareResource call")
-
-// NodePrepareResoucesCalled checks that NodePrepareResources API has been called
-var NodePrepareResourcesCalled = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
+// NodePrepareResoucesSucceeded checks that NodePrepareResources API has been called and succeeded
+var NodePrepareResourcesSucceeded = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
 	for _, call := range actualCalls {
 		if strings.HasSuffix(call.FullMethod, "/NodePrepareResources") && call.Err == nil {
 			return true, nil
 		}
 	}
 	return false, nil
-}).WithMessage("contain NodePrepareResources call")
+}).WithMessage("contain successful NodePrepareResources call")
+
+// NodePrepareResoucesErrored checks that NodePrepareResources API has been called and returned an error
+var NodePrepareResourcesErrored = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
+	for _, call := range actualCalls {
+		if strings.HasSuffix(call.FullMethod, "/NodePrepareResources") && call.Err != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}).WithMessage("contain unsuccessful NodePrepareResources call")
+
+// NodeUnprepareResoucesSucceeded checks that NodeUnprepareResources API has been called and succeeded
+var NodeUnprepareResourcesSucceeded = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
+	for _, call := range actualCalls {
+		if strings.HasSuffix(call.FullMethod, "/NodeUnprepareResources") && call.Err == nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}).WithMessage("contain successful NodeUnprepareResources call")
+
+// NodeUnprepareResoucesErrored checks that NodeUnprepareResources API has been called and returned an error
+var NodeUnprepareResourcesErrored = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
+	for _, call := range actualCalls {
+		if strings.HasSuffix(call.FullMethod, "/NodeUnprepareResources") && call.Err != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}).WithMessage("contain unsuccessful NodeUnprepareResources call")

--- a/test/e2e/dra/test-driver/app/server.go
+++ b/test/e2e/dra/test-driver/app/server.go
@@ -287,7 +287,7 @@ func NewCommand() *cobra.Command {
 			return fmt.Errorf("create socket directory: %w", err)
 		}
 
-		plugin, err := StartPlugin(cmd.Context(), *cdiDir, *driverName, "", FileOperations{},
+		plugin, err := StartPlugin(cmd.Context(), *cdiDir, *driverName, "", PluginConfig{},
 			kubeletplugin.PluginSocketPath(*endpoint),
 			kubeletplugin.RegistrarSocketPath(path.Join(*pluginRegistrationPath, *driverName+"-reg.sock")),
 			kubeletplugin.KubeletPluginSocketPath(*draAddress),

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -122,7 +122,7 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 			framework.ExpectNoError(err)
 
 			ginkgo.By("wait for NodePrepareResources call")
-			gomega.Eventually(kubeletPlugin.GetGRPCCalls).WithTimeout(dra.PluginClientTimeout * 2).Should(testdriver.NodePrepareResourcesCalled)
+			gomega.Eventually(kubeletPlugin.GetGRPCCalls).WithTimeout(dra.PluginClientTimeout * 2).Should(testdriver.NodePrepareResourcesSucceeded)
 
 			// TODO: Check condition or event when implemented
 			// see https://github.com/kubernetes/kubernetes/issues/118468 for details

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -26,6 +26,7 @@ package e2enode
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -97,7 +98,7 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 		ginkgo.It("must process pod created when kubelet is not running", func(ctx context.Context) {
 			// Stop Kubelet
 			startKubelet := stopKubelet()
-			pod := createTestObjects(ctx, f.ClientSet, getNodeName(ctx, f), f.Namespace.Name, "draclass", "external-claim", "drapod")
+			pod := createTestObjects(ctx, f.ClientSet, getNodeName(ctx, f), f.Namespace.Name, "draclass", "external-claim", "drapod", 0, true)
 			// Pod must be in pending state
 			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Pending", framework.PodStartShortTimeout, func(pod *v1.Pod) (bool, error) {
 				return pod.Status.Phase == v1.PodPending, nil
@@ -113,7 +114,7 @@ var _ = framework.SIGDescribe("node")("DRA", feature.DynamicResourceAllocation, 
 		ginkgo.It("must keep pod in pending state if NodePrepareResources times out", func(ctx context.Context) {
 			ginkgo.By("set delay for the NodePrepareResources call")
 			kubeletPlugin.Block()
-			pod := createTestObjects(ctx, f.ClientSet, getNodeName(ctx, f), f.Namespace.Name, "draclass", "external-claim", "drapod")
+			pod := createTestObjects(ctx, f.ClientSet, getNodeName(ctx, f), f.Namespace.Name, "draclass", "external-claim", "drapod", 0, true)
 
 			ginkgo.By("wait for pod to be in Pending state")
 			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Pending", framework.PodStartShortTimeout, func(pod *v1.Pod) (bool, error) {
@@ -170,7 +171,7 @@ func newKubeletPlugin(ctx context.Context, nodeName string) *testdriver.ExampleP
 // NOTE: as scheduler and controller manager are not running by the Node e2e,
 // the objects must contain all required data to be processed correctly by the API server
 // and placed on the node without involving the scheduler and the DRA controller
-func createTestObjects(ctx context.Context, clientSet kubernetes.Interface, nodename, namespace, className, claimName, podName string) *v1.Pod {
+func createTestObjects(ctx context.Context, clientSet kubernetes.Interface, nodename, namespace, className, claimName, podName string, sleepTime int, deferPodDeletion bool) *v1.Pod {
 	// ResourceClass
 	class := &resourcev1alpha2.ResourceClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -222,7 +223,7 @@ func createTestObjects(ctx context.Context, clientSet kubernetes.Interface, node
 					Resources: v1.ResourceRequirements{
 						Claims: []v1.ResourceClaim{{Name: podClaimName}},
 					},
-					Command: []string{"/bin/sh", "-c", "env | grep DRA_PARAM1=PARAM1_VALUE"},
+					Command: []string{"/bin/sh", "-c", fmt.Sprintf("env | grep DRA_PARAM1=PARAM1_VALUE && sleep %d", sleepTime)},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,
@@ -231,7 +232,9 @@ func createTestObjects(ctx context.Context, clientSet kubernetes.Interface, node
 	createdPod, err := clientSet.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	ginkgo.DeferCleanup(clientSet.CoreV1().Pods(namespace).Delete, podName, metav1.DeleteOptions{})
+	if deferPodDeletion {
+		ginkgo.DeferCleanup(clientSet.CoreV1().Pods(namespace).Delete, podName, metav1.DeleteOptions{})
+	}
 
 	// Update claim status: set ReservedFor and AllocationResult
 	// NOTE: This is usually done by the DRA controller


### PR DESCRIPTION
This is how I can imaging writing the new E2E node tests.

Note that `[sig-node] DRA [Feature:DynamicResourceAllocation] [NodeAlphaFeature:DynamicResourceAllocation] Resource Kubelet Plugin [Serial] [It] must call NodeUnprepareResources for deleted pod after Kubelet restart [sig-node, Feature:DynamicResourceAllocation, Serial]` fails for me, kubelet does not call NodeUnprepareResources again after the restart.

/assign @bart0sh 